### PR TITLE
Fix some problems with Big Sur, and more robust handling of python's dynamic library name

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,7 +16,6 @@ build --cxxopt="-std=c++14"
 build --cxxopt="-D_GLIBCXX_USE_CXX11_ABI=0"
 build --auto_output_filter=subpackages
 build --copt="-Wall" --copt="-Wno-sign-compare"
-build --linkopt="-lrt -lm"
 
 # TF isn't built in dbg mode, so our dbg builds will segfault due to inconsistency
 # of defines when using tf's headers.  In particular in refcount.h.

--- a/configure.py
+++ b/configure.py
@@ -38,7 +38,6 @@ Shamelessly taken from TensorFlow:
 """
 import argparse
 import os
-import platform
 import subprocess
 import sys
 
@@ -71,7 +70,7 @@ def main():
   setup_python(environ_cp)
 
   write_to_bazelrc('')
-  if platform.system() == 'Darwin':
+  if sys.platform == 'darwin':
     write_to_bazelrc('# https://github.com/googleapis/google-cloud-cpp-spanner/issues/1003')
     write_to_bazelrc('build --copt=-DGRPC_BAZEL_BUILD')
   else:

--- a/configure.py
+++ b/configure.py
@@ -38,6 +38,7 @@ Shamelessly taken from TensorFlow:
 """
 import argparse
 import os
+import platform
 import subprocess
 import sys
 
@@ -68,6 +69,13 @@ def main():
 
   reset_configure_bazelrc()
   setup_python(environ_cp)
+
+  write_to_bazelrc('\n')
+  if platform.system() == 'Darwin':
+    write_to_bazelrc('# https://github.com/googleapis/google-cloud-cpp-spanner/issues/1003')
+    write_to_bazelrc('build --copt=-DGRPC_BAZEL_BUILD')
+  else:
+    write_to_bazelrc('build --linkopt="-lrt -lm"')
 
 
 def get_from_env_or_user_or_default(environ_cp, var_name, ask_for_var,

--- a/configure.py
+++ b/configure.py
@@ -70,7 +70,7 @@ def main():
   reset_configure_bazelrc()
   setup_python(environ_cp)
 
-  write_to_bazelrc('\n')
+  write_to_bazelrc('')
   if platform.system() == 'Darwin':
     write_to_bazelrc('# https://github.com/googleapis/google-cloud-cpp-spanner/issues/1003')
     write_to_bazelrc('build --copt=-DGRPC_BAZEL_BUILD')

--- a/docker/dev.dockerfile
+++ b/docker/dev.dockerfile
@@ -80,6 +80,7 @@ ARG pip_dependencies=' \
       numpy \
       oauth2client \
       pandas \
+      platform \
       portpicker'
 
 

--- a/docker/release.dockerfile
+++ b/docker/release.dockerfile
@@ -63,6 +63,7 @@ ARG pip_dependencies=' \
       numpy \
       oauth2client \
       pandas \
+      platform \
       portpicker'
 
 # TODO(b/154930404): Update to 2.2.0 once it's out.  May need to

--- a/oss_build.sh
+++ b/oss_build.sh
@@ -104,7 +104,7 @@ for python_version in $PYTHON_VERSIONS; do
 
   if [ "$(uname)" = "Darwin" ]; then
     bazel_config=""
-    version=`sw_vers -productVersion | sed 's/\./_/g' | cut -d"_" -f1,2`
+    version=`${PYTHON_BIN_PATH} -c 'import platform; print(platform.mac_ver()[0].replace(".", "_"))'`
     PLATFORM="macosx_${version}_"`uname -m`
   else
     bazel_config="--config=manylinux2010"

--- a/oss_build.sh
+++ b/oss_build.sh
@@ -101,6 +101,8 @@ for python_version in $PYTHON_VERSIONS; do
       exit
     fi
 
+    export PYTHON_LIB_PATH=`$PYTHON_BIN_PATH -c 'import site; print("\\n".join(site.getsitepackages()))'`
+
     bazel_config=""
     version=`sw_vers -productVersion | sed 's/\./_/g' | cut -d"_" -f1,2`
     PLATFORM="macosx_${version}_x86_64"
@@ -139,7 +141,7 @@ for python_version in $PYTHON_VERSIONS; do
   ./bazel-bin/reverb/pip_package/build_pip_package --dst $OUTPUT_DIR $PIP_PKG_EXTRA_ARGS --platform "${PLATFORM}"
 
   # Installs pip package.
-  $PYTHON_BIN_PATH -mpip install ${OUTPUT_DIR}*${ABI}*.whl
+  $PYTHON_BIN_PATH -mpip install --force-reinstall ${OUTPUT_DIR}*${ABI}*.whl
 
   if [ "$PYTHON_TESTS" = "true" ]; then
     echo "Run Python tests..."

--- a/oss_build.sh
+++ b/oss_build.sh
@@ -102,7 +102,7 @@ for python_version in $PYTHON_VERSIONS; do
     fi
 
     bazel_config=""
-    version=`sw_vers | grep ProductVersion | awk '{print $2}' | sed 's/\./_/g' | cut -d"_" -f1,2`
+    version=`sw_vers -productVersion | sed 's/\./_/g' | cut -d"_" -f1,2`
     PLATFORM="macosx_${version}_x86_64"
   else
     if [ "$python_version" = "3.6" ]; then
@@ -132,11 +132,11 @@ for python_version in $PYTHON_VERSIONS; do
   # someone's system unexpectedly. We are executing the python tests after
   # installing the final package making this approach satisfactory.
   # TODO(b/157223742): Execute Python tests as well.
-  bazel test -c opt --copt=-mavx $bazel_config --test_output=errors //reverb/cc/...
+  bazel test -c opt --copt=-mavx ${bazel_config} --test_output=errors //reverb/cc/...
 
-  # # Builds Reverb and creates the wheel package.
-  bazel build -c opt --copt=-mavx $bazel_config reverb/pip_package:build_pip_package
-  ./bazel-bin/reverb/pip_package/build_pip_package --dst $OUTPUT_DIR $PIP_PKG_EXTRA_ARGS --plat "$PLATFORM"
+  # Builds Reverb and creates the wheel package.
+  bazel build -c opt --copt=-mavx ${bazel_config} reverb/pip_package:build_pip_package
+  ./bazel-bin/reverb/pip_package/build_pip_package --dst $OUTPUT_DIR $PIP_PKG_EXTRA_ARGS --platform "${PLATFORM}"
 
   # Installs pip package.
   $PYTHON_BIN_PATH -mpip install ${OUTPUT_DIR}*${ABI}*.whl
@@ -145,7 +145,7 @@ for python_version in $PYTHON_VERSIONS; do
     echo "Run Python tests..."
     set +e
 
-    bash run_python_tests.sh 2>&1| tee ./unittest_log.txt
+    bash run_python_tests.sh 2>&1 | tee ./unittest_log.txt
     UNIT_TEST_ERROR_CODE=$?
     set -e
     if [[ $UNIT_TEST_ERROR_CODE != 0 ]]; then

--- a/oss_build.sh
+++ b/oss_build.sh
@@ -88,40 +88,27 @@ for python_version in $PYTHON_VERSIONS; do
     bazel clean
   fi
 
+  if [ "$python_version" = "3.6" ]; then
+    ABI=cp36
+  elif [ "$python_version" = "3.7" ]; then
+    ABI=cp37
+  elif [ "$python_version" = "3.8" ]; then
+    ABI=cp38
+  else
+    echo "Error unknown --python. Only [3.6|3.7|3.8]"
+    exit 1
+  fi
+
+  export PYTHON_BIN_PATH=`which python${python_version}`
+  export PYTHON_LIB_PATH=`${PYTHON_BIN_PATH} -c 'import site; print(site.getsitepackages()[0])'`
+
   if [ "$(uname)" = "Darwin" ]; then
-    if [ "$python_version" = "3.6" ]; then
-      export PYTHON_BIN_PATH=python3.6
-    elif [ "$python_version" = "3.7" ]; then
-      export PYTHON_BIN_PATH=python3.7
-      ABI=cp37
-    elif [ "$python_version" = "3.8" ]; then
-      export PYTHON_BIN_PATH=python3.8
-      ABI=cp38
-    else
-      echo "Error unknown --python. Only [3.6|3.7|3.8]"
-      exit
-    fi
-
-    export PYTHON_LIB_PATH=`$PYTHON_BIN_PATH -c 'import site; print("\\n".join(site.getsitepackages()))'`
-
     bazel_config=""
     version=`sw_vers -productVersion | sed 's/\./_/g' | cut -d"_" -f1,2`
-    PLATFORM="macosx_${version}_x86_64"
+    PLATFORM="macosx_${version}_"`uname -m`
   else
-    if [ "$python_version" = "3.6" ]; then
-      export PYTHON_BIN_PATH=/usr/bin/python3.6 && export PYTHON_LIB_PATH=/usr/local/lib/python3.6/dist-packages
-    elif [ "$python_version" = "3.7" ]; then
-      export PYTHON_BIN_PATH=/usr/local/bin/python3.7 && export PYTHON_LIB_PATH=/usr/local/lib/python3.7/dist-packages
-      ABI=cp37
-    elif [ "$python_version" = "3.8" ]; then
-      export PYTHON_BIN_PATH=/usr/bin/python3.8 && export PYTHON_LIB_PATH=/usr/local/lib/python3.8/dist-packages
-      ABI=cp38
-    else
-      echo "Error unknown --python. Only [3.6|3.7|3.8]"
-      exit
-    fi
-
     bazel_config="--config=manylinux2010"
+    bazel_config=""
     PLATFORM="manylinux2010_x86_64"
   fi
 

--- a/reverb/BUILD
+++ b/reverb/BUILD
@@ -16,6 +16,15 @@ licenses(["notice"])
 
 exports_files(["LICENSE"])
 
+config_setting(
+    name = "macos",
+    values = {
+        "apple_platform_type": "macos",
+        "cpu": "darwin",
+    },
+    visibility = ["//visibility:public"],
+)
+
 reverb_pytype_strict_library(
     name = "reverb",
     srcs = ["__init__.py"],

--- a/reverb/cc/platform/default/build_rules.bzl
+++ b/reverb/cc/platform/default/build_rules.bzl
@@ -293,6 +293,14 @@ def reverb_gen_op_wrapper_py(name, out, kernel_lib, linkopts = [], **kwargs):
         fail("Argument out must end with '.py', but saw: {}".format(out))
 
     module_name = "lib{}_gen_op".format(name)
+    exported_symbols_file = "%s-exported-symbols.lds" % module_name
+    native.genrule(
+        name = module_name + "_exported_symbols",
+        outs = [exported_symbols_file],
+        cmd = "echo '*ReverbDataset*\n*ReverbClient*' >$@",
+        output_licenses = ["unencumbered"],
+        visibility = ["//visibility:private"],
+    )
     version_script_file = "%s-version-script.lds" % module_name
     native.genrule(
         name = module_name + "_version_script",
@@ -303,20 +311,25 @@ def reverb_gen_op_wrapper_py(name, out, kernel_lib, linkopts = [], **kwargs):
     )
     native.cc_binary(
         name = "{}.so".format(module_name),
-        deps = [kernel_lib] + reverb_tf_deps() + [version_script_file],
+        deps = [kernel_lib] + reverb_tf_deps() + [
+            exported_symbols_file,
+            version_script_file
+        ],
         copts = tf_copts() + [
             "-fno-strict-aliasing",  # allow a wider range of code [aliasing] to compile.
-            "-fvisibility=hidden",  # avoid symbol clashes between DSOs.
-        ],
+        ]+ select({
+            "//reverb:macos": [],
+            "//conditions:default": [
+                "-fvisibility=hidden",  # avoid symbol clashes between DSOs.
+            ],
+        }),
         linkshared = 1,
         linkopts = linkopts + _rpath_linkopts(module_name) + select({
             "//reverb:macos": [
-                "-Wl",
-                "$(location %s)" % version_script_file,
+                "-Wl,-exported_symbols_list,$(location %s)" % exported_symbols_file,
             ],
             "//conditions:default": [
-                "-Wl,--version-script",
-                "$(location %s)" % version_script_file,
+                "-Wl,--version-script,$(location %s)" % version_script_file,
             ],
         }),
         **kwargs

--- a/reverb/cc/platform/default/build_rules.bzl
+++ b/reverb/cc/platform/default/build_rules.bzl
@@ -107,7 +107,7 @@ def reverb_cc_proto_library(name, srcs = [], deps = [], **kwargs):
         name = "{}_static".format(name),
         srcs = gen_srcs,
         hdrs = gen_hdrs,
-        deps = depset(deps + reverb_tf_deps()),
+        deps = depset([dep.replace(":", ":lib") + ".so" for dep in deps] + reverb_tf_deps()),
         alwayslink = 1,
         **kwargs
     )
@@ -294,8 +294,8 @@ def reverb_gen_op_wrapper_py(name, out, kernel_lib, linkopts = [], **kwargs):
 
     module_name = "lib{}_gen_op".format(name)
     exported_symbols_file = "%s-exported-symbols.lds" % module_name
-    # gen_client_ops -> ReverbClient
-    symbol = "Reverb{}".format(name.split('_')[1].capitalize())
+    # gen_client_ops -> reverb_client
+    symbol = "reverb_{}".format(name.split('_')[1])
     native.genrule(
         name = module_name + "_exported_symbols",
         outs = [exported_symbols_file],

--- a/reverb/cc/platform/default/build_rules.bzl
+++ b/reverb/cc/platform/default/build_rules.bzl
@@ -294,10 +294,12 @@ def reverb_gen_op_wrapper_py(name, out, kernel_lib, linkopts = [], **kwargs):
 
     module_name = "lib{}_gen_op".format(name)
     exported_symbols_file = "%s-exported-symbols.lds" % module_name
+    # gen_client_ops -> ReverbClient
+    symbol = "Reverb{}".format(name.split('_')[1].capitalize())
     native.genrule(
         name = module_name + "_exported_symbols",
         outs = [exported_symbols_file],
-        cmd = "echo '*ReverbDataset*\n*ReverbClient*' >$@",
+        cmd = "echo '*%s*' >$@" % symbol,
         output_licenses = ["unencumbered"],
         visibility = ["//visibility:private"],
     )
@@ -317,12 +319,8 @@ def reverb_gen_op_wrapper_py(name, out, kernel_lib, linkopts = [], **kwargs):
         ],
         copts = tf_copts() + [
             "-fno-strict-aliasing",  # allow a wider range of code [aliasing] to compile.
-        ]+ select({
-            "//reverb:macos": [],
-            "//conditions:default": [
-                "-fvisibility=hidden",  # avoid symbol clashes between DSOs.
-            ],
-        }),
+            "-fvisibility=hidden",  # avoid symbol clashes between DSOs.
+        ],
         linkshared = 1,
         linkopts = linkopts + _rpath_linkopts(module_name) + select({
             "//reverb:macos": [

--- a/reverb/cc/platform/default/build_rules.bzl
+++ b/reverb/cc/platform/default/build_rules.bzl
@@ -310,7 +310,6 @@ def reverb_gen_op_wrapper_py(name, out, kernel_lib, linkopts = [], **kwargs):
         ],
         linkshared = 1,
         linkopts = linkopts + _rpath_linkopts(module_name) + [
-            "-Wl,--version-script",
             "$(location %s)" % version_script_file,
         ],
         **kwargs
@@ -359,7 +358,14 @@ def _rpath_linkopts(name):
     # ops) are picked up as long as they are in either the same or a parent
     # directory in the tensorflow/ tree.
     levels_to_root = native.package_name().count("/") + name.count("/")
-    return ["-Wl,%s" % (_make_search_paths("$$ORIGIN", levels_to_root),)]
+    return select({
+        "//reverb:macos": [
+            "-Wl,%s" % (_make_search_paths("$$ORIGIN", levels_to_root),),
+        ],
+        "//conditions:default": [
+            "-Wl,--version-script,%s" % (_make_search_paths("$$ORIGIN", levels_to_root),),
+        ],
+    })
 
 def reverb_pybind_extension(
         name,
@@ -442,7 +448,6 @@ def reverb_pybind_extension(
             "-fvisibility=hidden",  # avoid pybind symbol clashes between DSOs.
         ],
         linkopts = linkopts + _rpath_linkopts(module_name) + [
-            "-Wl,--version-script",
             "$(location %s)" % version_script_file,
         ],
         deps = depset(deps + [

--- a/reverb/cc/platform/default/build_rules.bzl
+++ b/reverb/cc/platform/default/build_rules.bzl
@@ -309,9 +309,16 @@ def reverb_gen_op_wrapper_py(name, out, kernel_lib, linkopts = [], **kwargs):
             "-fvisibility=hidden",  # avoid symbol clashes between DSOs.
         ],
         linkshared = 1,
-        linkopts = linkopts + _rpath_linkopts(module_name) + [
-            "$(location %s)" % version_script_file,
-        ],
+        linkopts = linkopts + _rpath_linkopts(module_name) + select({
+            "//reverb:macos": [
+                "-Wl",
+                "$(location %s)" % version_script_file,
+            ],
+            "//conditions:default": [
+                "-Wl,--version-script",
+                "$(location %s)" % version_script_file,
+            ],
+        }),
         **kwargs
     )
     native.genrule(
@@ -358,14 +365,7 @@ def _rpath_linkopts(name):
     # ops) are picked up as long as they are in either the same or a parent
     # directory in the tensorflow/ tree.
     levels_to_root = native.package_name().count("/") + name.count("/")
-    return select({
-        "//reverb:macos": [
-            "-Wl,%s" % (_make_search_paths("$$ORIGIN", levels_to_root),),
-        ],
-        "//conditions:default": [
-            "-Wl,--version-script,%s" % (_make_search_paths("$$ORIGIN", levels_to_root),),
-        ],
-    })
+    return ["-Wl,%s" % (_make_search_paths("$$ORIGIN", levels_to_root),)]
 
 def reverb_pybind_extension(
         name,
@@ -447,9 +447,15 @@ def reverb_pybind_extension(
             "-fexceptions",  # pybind relies on exceptions, required to compile.
             "-fvisibility=hidden",  # avoid pybind symbol clashes between DSOs.
         ],
-        linkopts = linkopts + _rpath_linkopts(module_name) + [
-            "$(location %s)" % version_script_file,
-        ],
+        linkopts = linkopts + _rpath_linkopts(module_name) +
+            select({"//reverb:macos": [
+                        "-Wl,-exported_symbols_list,$(location %s)" % exported_symbols_file,
+                    ],
+                    "//conditions:default": [
+                        "-Wl,--version-script",
+                        "$(location %s)" % version_script_file,
+                    ],
+        }),
         deps = depset(deps + [
             exported_symbols_file,
             version_script_file,

--- a/reverb/cc/platform/default/repo.bzl
+++ b/reverb/cc/platform/default/repo.bzl
@@ -86,29 +86,14 @@ def _find_python_solib_path(repo_ctx):
         [
             get_python_path(repo_ctx),
             "-c",
-            "import sys; vi = sys.version_info; " +
-            "sys.stdout.write('python{}.{}'.format(vi.major, vi.minor))",
+            "import sysconfig;" +
+            "print('\\n'.join(sysconfig.get_config_vars('LIBDIR', 'INSTSONAME')))"
         ],
     )
     if exec_result.return_code != 0:
         fail("Could not locate python shared library path:\n{}"
             .format(exec_result.stderr))
-    version = exec_result.stdout.splitlines()[-1]
-    exec_result = repo_ctx.execute(
-        ["{}-config".format(version), "--configdir"],
-        quiet = True,
-    )
-    if exec_result.return_code != 0:
-        fail("Could not locate python shared library path:\n{}"
-            .format(exec_result.stderr))
-
-    if is_darwin(repo_ctx):
-        basename = "lib{}m.dylib".format(version)
-        solib_dir = "/".join(exec_result.stdout.splitlines()[-1].split("/")[:-2])
-    else:
-        basename = "lib{}.so".format(version)
-        solib_dir = exec_result.stdout.splitlines()[-1]
-
+    solib_dir, basename = exec_result.stdout.splitlines()
     full_path = repo_ctx.path("{}/{}".format(solib_dir, basename))
     if not full_path.exists:
         basename = basename.replace('m.dylib', '.dylib')

--- a/reverb/cc/platform/default/repo.bzl
+++ b/reverb/cc/platform/default/repo.bzl
@@ -254,6 +254,11 @@ def _python_includes_repo_impl(repo_ctx):
         python_solib.basename,
     )
 
+    python_includes_srcs = 'srcs = ["%s"],' % python_solib.basename
+    if is_darwin(repo_ctx):
+        # Fix Fatal Python error: PyThreadState_Get: no current thread
+        python_includes_srcs = ""
+
     # Note, "@python_includes" is a misnomer since we include the
     # libpythonX.Y.so in the srcs, so we can get access to python's various
     # symbols at link time.
@@ -263,7 +268,7 @@ def _python_includes_repo_impl(repo_ctx):
 cc_library(
     name = "python_includes",
     hdrs = glob(["python_includes/**/*.h"]),
-    srcs = ["{}"],
+    {}
     includes = ["python_includes"],
     visibility = ["//visibility:public"],
 )
@@ -273,7 +278,7 @@ cc_library(
     includes = ["numpy_includes"],
     visibility = ["//visibility:public"],
 )
-""".format(python_solib.basename),
+""".format(python_includes_srcs),
         executable = False,
     )
 

--- a/reverb/cc/platform/default/repo.bzl
+++ b/reverb/cc/platform/default/repo.bzl
@@ -90,9 +90,6 @@ def _find_python_solib_path(repo_ctx):
             .format(exec_result.stderr))
     version = exec_result.stdout.splitlines()[-1]
     basename = "lib{}.so".format(version)
-    if repo_ctx.os.name.lower().find("mac") != -1:
-        basename = "lib{}m.a".format(version)
-
     exec_result = repo_ctx.execute(
         ["{}-config".format(version), "--configdir"],
         quiet = True,
@@ -101,6 +98,10 @@ def _find_python_solib_path(repo_ctx):
         fail("Could not locate python shared library path:\n{}"
             .format(exec_result.stderr))
     solib_dir = exec_result.stdout.splitlines()[-1]
+    if repo_ctx.os.name.lower().find("mac") != -1:
+        basename = "lib{}m.dylib".format(version)
+        solib_dir = "/".join(solib_dir.split("/")[:-2])
+
     full_path = repo_ctx.path("{}/{}".format(solib_dir, basename))
     if not full_path.exists:
         fail("Unable to find python shared library file:\n{}/{}"
@@ -222,7 +223,7 @@ filegroup(
 def _tensorflow_solib_repo_impl(repo_ctx):
     tf_lib_path = _find_tf_lib_path(repo_ctx)
     repo_ctx.symlink(tf_lib_path, "tensorflow_solib")
-    suffix = "2.so"
+    suffix = "so.2"
     if repo_ctx.os.name.lower().find("mac") != -1:
         suffix = "2.dylib"
 

--- a/reverb/cc/platform/default/repo.bzl
+++ b/reverb/cc/platform/default/repo.bzl
@@ -94,7 +94,6 @@ def _find_python_solib_path(repo_ctx):
         fail("Could not locate python shared library path:\n{}"
             .format(exec_result.stderr))
     version = exec_result.stdout.splitlines()[-1]
-    basename = "lib{}.so".format(version)
     exec_result = repo_ctx.execute(
         ["{}-config".format(version), "--configdir"],
         quiet = True,
@@ -102,10 +101,13 @@ def _find_python_solib_path(repo_ctx):
     if exec_result.return_code != 0:
         fail("Could not locate python shared library path:\n{}"
             .format(exec_result.stderr))
-    solib_dir = exec_result.stdout.splitlines()[-1]
+
     if is_darwin(repo_ctx):
         basename = "lib{}m.dylib".format(version)
-        solib_dir = "/".join(solib_dir.split("/")[:-2])
+        solib_dir = "/".join(exec_result.stdout.splitlines()[-1].split("/")[:-2])
+    else:
+        basename = "lib{}.so".format(version)
+        solib_dir = exec_result.stdout.splitlines()[-1]
 
     full_path = repo_ctx.path("{}/{}".format(solib_dir, basename))
     if not full_path.exists:
@@ -228,20 +230,21 @@ filegroup(
 def _tensorflow_solib_repo_impl(repo_ctx):
     tf_lib_path = _find_tf_lib_path(repo_ctx)
     repo_ctx.symlink(tf_lib_path, "tensorflow_solib")
-    suffix = "so.2"
     if is_darwin(repo_ctx):
         suffix = "2.dylib"
+    else:
+        suffix = "so.2"
 
     repo_ctx.file(
         "BUILD",
         content = """
 cc_library(
     name = "framework_lib",
-    srcs = ["tensorflow_solib/libtensorflow_framework.{}"],
+    srcs = ["tensorflow_solib/libtensorflow_framework.{suffix}"],
     deps = ["@python_includes", "@python_includes//:numpy_includes"],
     visibility = ["//visibility:public"],
 )
-""".format(suffix))
+""".format(suffix=suffix))
 
 def _python_includes_repo_impl(repo_ctx):
     python_include_path = _find_python_include_path(repo_ctx)
@@ -254,10 +257,11 @@ def _python_includes_repo_impl(repo_ctx):
         python_solib.basename,
     )
 
-    python_includes_srcs = 'srcs = ["%s"],' % python_solib.basename
     if is_darwin(repo_ctx):
         # Fix Fatal Python error: PyThreadState_Get: no current thread
         python_includes_srcs = ""
+    else:
+        python_includes_srcs = 'srcs = ["%s"],' % python_solib.basename
 
     # Note, "@python_includes" is a misnomer since we include the
     # libpythonX.Y.so in the srcs, so we can get access to python's various
@@ -268,7 +272,7 @@ def _python_includes_repo_impl(repo_ctx):
 cc_library(
     name = "python_includes",
     hdrs = glob(["python_includes/**/*.h"]),
-    {}
+    {srcs}
     includes = ["python_includes"],
     visibility = ["//visibility:public"],
 )
@@ -278,7 +282,7 @@ cc_library(
     includes = ["numpy_includes"],
     visibility = ["//visibility:public"],
 )
-""".format(python_includes_srcs),
+""".format(srcs=python_includes_srcs),
         executable = False,
     )
 
@@ -346,15 +350,15 @@ def _reverb_protoc_archive(ctx):
         sha256 = ""
         version = override_version
 
-    urls = [
-        "https://github.com/protocolbuffers/protobuf/releases/download/v%s/protoc-%s-linux-x86_64.zip" % (version, version),
-    ]
     if is_darwin(ctx):
-        urls = [
-            "https://github.com/protocolbuffers/protobuf/releases/download/v%s/protoc-%s-osx-x86_64.zip" % (version, version),
-        ]
-        sha256 = ""  # TODO(Feiteng) set this in WORKSPACE
+        platform = "osx"
+        sha256 = ""
+    else:
+        platform = "linux"
 
+    urls = [
+        "https://github.com/protocolbuffers/protobuf/releases/download/v%s/protoc-%s-%s-x86_64.zip" % (version, version, platform),
+    ]
     ctx.download_and_extract(
         url = urls,
         sha256 = sha256,

--- a/reverb/cc/platform/default/repo.bzl
+++ b/reverb/cc/platform/default/repo.bzl
@@ -2,6 +2,11 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+def is_darwin(ctx):
+    if ctx.os.name.lower().find("mac") != -1:
+        return True
+    return False
+
 # Sanitize a dependency so that it works correctly from code that includes
 # reverb as a submodule.
 def clean_dep(dep):
@@ -98,7 +103,7 @@ def _find_python_solib_path(repo_ctx):
         fail("Could not locate python shared library path:\n{}"
             .format(exec_result.stderr))
     solib_dir = exec_result.stdout.splitlines()[-1]
-    if repo_ctx.os.name.lower().find("mac") != -1:
+    if is_darwin(repo_ctx):
         basename = "lib{}m.dylib".format(version)
         solib_dir = "/".join(solib_dir.split("/")[:-2])
 
@@ -224,7 +229,7 @@ def _tensorflow_solib_repo_impl(repo_ctx):
     tf_lib_path = _find_tf_lib_path(repo_ctx)
     repo_ctx.symlink(tf_lib_path, "tensorflow_solib")
     suffix = "so.2"
-    if repo_ctx.os.name.lower().find("mac") != -1:
+    if is_darwin(repo_ctx):
         suffix = "2.dylib"
 
     repo_ctx.file(
@@ -339,7 +344,7 @@ def _reverb_protoc_archive(ctx):
     urls = [
         "https://github.com/protocolbuffers/protobuf/releases/download/v%s/protoc-%s-linux-x86_64.zip" % (version, version),
     ]
-    if ctx.os.name.lower().find("mac") != -1:
+    if is_darwin(ctx):
         urls = [
             "https://github.com/protocolbuffers/protobuf/releases/download/v%s/protoc-%s-osx-x86_64.zip" % (version, version),
         ]

--- a/reverb/cc/platform/default/repo.bzl
+++ b/reverb/cc/platform/default/repo.bzl
@@ -111,8 +111,11 @@ def _find_python_solib_path(repo_ctx):
 
     full_path = repo_ctx.path("{}/{}".format(solib_dir, basename))
     if not full_path.exists:
-        fail("Unable to find python shared library file:\n{}/{}"
-            .format(solib_dir, basename))
+        basename = basename.replace('m.dylib', '.dylib')
+        full_path = repo_ctx.path("{}/{}".format(solib_dir, basename))
+        if not full_path.exists:
+            fail("Unable to find python shared library file:\n{}/{}"
+                .format(solib_dir, basename))
     return struct(dir = solib_dir, basename = basename)
 
 def _eigen_archive_repo_impl(repo_ctx):

--- a/reverb/pip_package/build_pip_package.sh
+++ b/reverb/pip_package/build_pip_package.sh
@@ -32,7 +32,7 @@ function build_wheel() {
   pushd ${TMPDIR} > /dev/null
 
   echo $(date) : "=== Building wheel"
-  "${PYTHON_BIN_PATH}" setup.py bdist_wheel ${PKG_NAME_FLAG} ${RELEASE_FLAG} ${TF_VERSION_FLAG} --plat manylinux2010_x86_64 > /dev/null
+  "${PYTHON_BIN_PATH}" setup.py bdist_wheel ${PKG_NAME_FLAG} ${RELEASE_FLAG} ${TF_VERSION_FLAG} --plat $PLATFORM > /dev/null
   DEST=${TMPDIR}/dist/
   if [[ ! "$TMPDIR" -ef "$DESTDIR" ]]; then
     mkdir -p ${DESTDIR}
@@ -80,6 +80,7 @@ function usage() {
   echo "    --release         build a release version"
   echo "    --dst             path to copy the .whl into."
   echo "    --tf-version      tensorflow version dependency passed to setup.py."
+  echo "    --plat            platform."
   echo ""
   exit 1
 }
@@ -90,6 +91,8 @@ function main() {
   TF_VERSION_FLAG=""
   # This is where the source code is copied and where the whl will be built.
   DST_DIR=""
+
+  PLATFORM="manylinux2010_x86_64"
 
   while true; do
     if [[ "$1" == "--help" ]]; then
@@ -103,6 +106,9 @@ function main() {
     elif [[ "$1" == "--tf-version" ]]; then
       shift
       TF_VERSION_FLAG="--tf-version $1"
+    elif [[ "$1" == "--plat" ]]; then
+      shift
+      PLATFORM=$1
     fi
 
     if [[ -z "$1" ]]; then

--- a/reverb/pip_package/build_pip_package.sh
+++ b/reverb/pip_package/build_pip_package.sh
@@ -32,7 +32,7 @@ function build_wheel() {
   pushd ${TMPDIR} > /dev/null
 
   echo $(date) : "=== Building wheel"
-  "${PYTHON_BIN_PATH}" setup.py bdist_wheel ${PKG_NAME_FLAG} ${RELEASE_FLAG} ${TF_VERSION_FLAG} --plat $PLATFORM > /dev/null
+  "${PYTHON_BIN_PATH}" setup.py bdist_wheel ${PKG_NAME_FLAG} ${RELEASE_FLAG} ${TF_VERSION_FLAG} --plat ${PLATFORM} > /dev/null
   DEST=${TMPDIR}/dist/
   if [[ ! "$TMPDIR" -ef "$DESTDIR" ]]; then
     mkdir -p ${DESTDIR}
@@ -106,7 +106,7 @@ function main() {
     elif [[ "$1" == "--tf-version" ]]; then
       shift
       TF_VERSION_FLAG="--tf-version $1"
-    elif [[ "$1" == "--plat" ]]; then
+    elif [[ "$1" == "--platform" ]]; then
       shift
       PLATFORM=$1
     fi

--- a/reverb/pip_package/build_pip_package.sh
+++ b/reverb/pip_package/build_pip_package.sh
@@ -71,6 +71,19 @@ function prepare_src() {
   # must remain where they are for TF to find them.
   find "${TMPDIR}/reverb/cc" -type d -name ops -prune -o -name '*.so' \
     -exec mv {} "${TMPDIR}/reverb" \;
+
+  # Copy darwin libs over so they can be loaded at runtime
+  so_lib_dir=$(ls $RUNFILES | grep solib) || true
+  if [ -n "${so_lib_dir}" ]; then
+    mkdir -p "${TMPDIR}/${so_lib_dir}"
+    proto_so_dir=$(ls ${RUNFILES}/${so_lib_dir} | grep proto) || true
+    for dir in ${proto_so_dir}; do
+      echo "===== DIR = $dir"
+      cp -R ${RUNFILES}/${so_lib_dir}/${dir} "${TMPDIR}/${so_lib_dir}"
+    done
+
+    cp -r $TMPDIR/${so_lib_dir} `dirname $PYTHON_LIB_PATH`
+  fi
 }
 
 function usage() {

--- a/reverb/pip_package/setup.py
+++ b/reverb/pip_package/setup.py
@@ -111,6 +111,16 @@ class SetupToolsHelper(object):
       long_description = f.read()
 
     version, project_name = self._get_version()
+
+    so_lib_paths = [
+        i for i in os.listdir('.')
+        if os.path.isdir(i) and fnmatch.fnmatch(i, '_solib_*')
+    ]
+
+    matches = []
+    for path in so_lib_paths:
+      matches.extend(['../' + x for x in find_files('*', path) if '.py' not in x])
+
     setup(
         name=project_name,
         version=version,
@@ -125,6 +135,9 @@ class SetupToolsHelper(object):
         packages=find_packages(),
         headers=list(find_files('*.proto', 'reverb')),
         include_package_data=True,
+        package_data={
+            'reverb': matches,
+        },
         install_requires=self._get_required_packages(),
         extras_require={
             'tensorflow': self._get_tensorflow_packages(),


### PR DESCRIPTION
Hi,

This removes the use of `sw_vers` in `oss_build.sh`, since for macOS 11.4 (Big Sur), `sw_vers` returns `11.4` while the valid tag for pip is actually `10.16`. 

This also uses `sysconfig` to more robustly find the python's dylib path. 

This commit is also ready to merge the reverb upstream v0.3.0.  See my branch https://github.com/thisiscam/reverb/tree/osx_merge_v030 for a merged version.